### PR TITLE
Utility, Get Combinations userId e itemId, from indexes

### DIFF
--- a/src/Recommender.php
+++ b/src/Recommender.php
@@ -255,34 +255,41 @@ class Recommender
         $combinations = [];
         
         $this->checkFit();
-
+    
         $userIds = array_keys($this->userMap);
         $itemIds = array_keys($this->itemMap);
-
+    
+        // Handle specific user or item
         if ($specificUserId !== null) {
             if (!isset($this->userMap[$specificUserId])) {
-                throw new \InvalidArgumentException('Specified user ID does not exist');
+                throw new \InvalidArgumentException('The specified user ID does not exist');
             }
             $userIds = [$specificUserId];
         }
-
+    
         if ($specificItemId !== null) {
             if (!isset($this->itemMap[$specificItemId])) {
-                throw new \InvalidArgumentException('Specified item ID does not exist');
+                throw new \InvalidArgumentException('The specified item ID does not exist');
             }
             $itemIds = [$specificItemId];
         }
-
+    
+        if ($specificUserId !== null && $specificItemId !== null) {
+            if (count($userIds) === 1 && count($itemIds) === 1) {
+                return [['user_id' => $specificUserId, 'item_id' => $specificItemId]];
+            }
+        }
+    
         $totalCombinations = count($userIds) * count($itemIds);
-
+    
         if ($end === null || $end > $totalCombinations) {
             $end = $totalCombinations;
         }
-
+    
         if ($start < 0 || $end < 0 || $start >= $end || $start >= $totalCombinations) {
             throw new \InvalidArgumentException('Invalid start or end index');
         }
-
+    
         $combinationCount = 0;
         foreach ($userIds as $userId) {
             foreach ($itemIds as $itemId) {
@@ -290,7 +297,7 @@ class Recommender
                     $combinations[] = ['user_id' => $userId, 'item_id' => $itemId];
                 }
                 $combinationCount++;
-
+    
                 if ($combinationCount >= $end) {
                     return $combinations;
                 }

--- a/src/Recommender.php
+++ b/src/Recommender.php
@@ -259,7 +259,6 @@ class Recommender
         $userIds = array_keys($this->userMap);
         $itemIds = array_keys($this->itemMap);
     
-        // Handle specific user or item
         if ($specificUserId !== null) {
             if (!isset($this->userMap[$specificUserId])) {
                 throw new \InvalidArgumentException('The specified user ID does not exist');

--- a/src/Recommender.php
+++ b/src/Recommender.php
@@ -250,6 +250,41 @@ class Recommender
         }
     }
 
+    public function getUserItemCombinations($start = 0, $end = null)
+    {
+        $combinations = [];
+        
+        $this->checkFit();
+
+        $userIds = array_keys($this->userMap);
+        $itemIds = array_keys($this->itemMap);
+
+        $totalCombinations = count($userIds) * count($itemIds);
+
+        if ($end === null || $end > $totalCombinations) {
+            $end = $totalCombinations;
+        }
+
+        if ($start < 0 || $end < 0 || $start >= $end || $start >= $totalCombinations) {
+            throw new \InvalidArgumentException('Invalid start or end index');
+        }
+
+        $combinationCount = 0;
+        foreach ($userIds as $userId) {
+            foreach ($itemIds as $itemId) {
+                if ($combinationCount >= $start && $combinationCount < $end) {
+                    $combinations[] = ['user_id' => $userId, 'item_id' => $itemId];
+                }
+                $combinationCount++;
+
+                if ($combinationCount >= $end) {
+                    return $combinations;
+                }
+            }
+        }
+        return $combinations;
+    }
+    
     private function userNorms()
     {
         return ($this->userNorms ??= $this->norms($this->userFactors));

--- a/src/Recommender.php
+++ b/src/Recommender.php
@@ -250,7 +250,7 @@ class Recommender
         }
     }
 
-    public function getUserItemCombinations($start = 0, $end = null)
+    public function getUserItemCombinations($start = 0, $end = null, $specificUserId = null, $specificItemId = null)
     {
         $combinations = [];
         
@@ -258,6 +258,20 @@ class Recommender
 
         $userIds = array_keys($this->userMap);
         $itemIds = array_keys($this->itemMap);
+
+        if ($specificUserId !== null) {
+            if (!isset($this->userMap[$specificUserId])) {
+                throw new \InvalidArgumentException('Specified user ID does not exist');
+            }
+            $userIds = [$specificUserId];
+        }
+
+        if ($specificItemId !== null) {
+            if (!isset($this->itemMap[$specificItemId])) {
+                throw new \InvalidArgumentException('Specified item ID does not exist');
+            }
+            $itemIds = [$specificItemId];
+        }
 
         $totalCombinations = count($userIds) * count($itemIds);
 


### PR DESCRIPTION
In our case, we found it really useful for handling prediction cases by limiting to indexes, avoiding further code changes.

```
// Get combinations from index 0 to 10
$combinations = $recommender->getUserItemCombinations(0, 10);
$recommender->predict($combinations);
```
or 
```
// Get all combinations
$combinations = $recommender->getUserItemCombinations();
$recommender->predict($combinations);
```
or
```
// Get combinations for user with ID 1, from index 0 to 10
$specificUserId = 1;
$combinations = $recommender->getUserItemCombinations(0, 10, $specificUserId);
$recommender->predict($combinations);
```
or
```
// Get combinations for item with ID 1, from index 0 to 10
$specificItemId = 1;
$combinations = $recommender->getUserItemCombinations(0, 10, null, $specificItemId);
$recommender->predict($combinations);
```
